### PR TITLE
👑メンバー追加イベントの作成 #58

### DIFF
--- a/src/app/Events/MemberAdded.php
+++ b/src/app/Events/MemberAdded.php
@@ -37,6 +37,6 @@ class MemberAdded implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('member-added-channel-' . $this->roomId, $this->userId);
+        return new PrivateChannel('member-added-channel.' . $this->roomId, $this->userId);
     }
 }

--- a/src/app/Events/MemberAdded.php
+++ b/src/app/Events/MemberAdded.php
@@ -9,19 +9,22 @@ use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 
 class MemberAdded implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    public $userId;
+
     /**
      * Create a new event instance.
      *
-     * @return void
+     * @param int $userId
      */
-    public function __construct()
+    public function __construct(int $userId)
     {
-        //
+        $this->userId = $userId;
     }
 
     /**
@@ -31,5 +34,6 @@ class MemberAdded implements ShouldBroadcast
      */
     public function broadcastOn()
     {
+        return new PrivateChannel('member-added-channel', $this->userId);
     }
 }

--- a/src/app/Events/MemberAdded.php
+++ b/src/app/Events/MemberAdded.php
@@ -16,15 +16,18 @@ class MemberAdded implements ShouldBroadcast
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public $userId;
+    public $roomId;
 
     /**
      * Create a new event instance.
      *
      * @param int $userId
+     * @param int $roomId
      */
-    public function __construct(int $userId)
+    public function __construct(int $userId, int $roomId)
     {
         $this->userId = $userId;
+        $this->roomId = $roomId;
     }
 
     /**
@@ -34,6 +37,6 @@ class MemberAdded implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return new PrivateChannel('member-added-channel', $this->userId);
+        return new PrivateChannel('member-added-channel-' . $this->roomId, $this->userId);
     }
 }

--- a/src/app/Repositories/RoomRepository.php
+++ b/src/app/Repositories/RoomRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories;
 
+use App\Events\MemberAdded;
 use App\Models\Room;
 use App\Models\Space;
 use Illuminate\Support\Facades\Auth;
@@ -84,6 +85,8 @@ class RoomRepository
         // Roomテーブルのmember_countを1足してDB更新
         $room->member_count = $room['member_count'] + 1;
         $room->save();
+
+        event(new MemberAdded($userId));
 
         return true;
 

--- a/src/app/Repositories/RoomRepository.php
+++ b/src/app/Repositories/RoomRepository.php
@@ -86,7 +86,7 @@ class RoomRepository
         $room->member_count = $room['member_count'] + 1;
         $room->save();
 
-        event(new MemberAdded($userId));
+        event(new MemberAdded($userId, $roomId));
 
         return true;
 

--- a/src/tests/Feature/RoomTest.php
+++ b/src/tests/Feature/RoomTest.php
@@ -555,7 +555,6 @@ class RoomTest extends TestCase
     {
         Event::fake();
 
-        $roomModel = new Room;
         $user = factory(User::class)->create();
         $board = $this->createBoard();
         $uname = uniqid();
@@ -570,7 +569,7 @@ class RoomTest extends TestCase
             'status'    => config('const.room_status_open')
         ]);
 
-        $room = $roomModel::where([
+        $room = Room::where([
             'id' => $room->id
         ])->first();
 

--- a/src/tests/Feature/RoomTest.php
+++ b/src/tests/Feature/RoomTest.php
@@ -571,7 +571,7 @@ class RoomTest extends TestCase
             'status'    => config('const.room_status_open')
         ]);
 
-        event($roomRepository->addMember($user->id, $room->id));
+        $roomRepository->addMember($user->id, $room->id);
 
         Event::assertDispatched(MemberAdded::class);
     }

--- a/src/tests/Feature/RoomTest.php
+++ b/src/tests/Feature/RoomTest.php
@@ -555,6 +555,8 @@ class RoomTest extends TestCase
     {
         Event::fake();
 
+        $roomRepository = new RoomRepository();
+
         $user = factory(User::class)->create();
         $board = $this->createBoard();
         $uname = uniqid();
@@ -569,11 +571,7 @@ class RoomTest extends TestCase
             'status'    => config('const.room_status_open')
         ]);
 
-        $room = Room::where([
-            'id' => $room->id
-        ])->first();
-
-        event(new MemberAdded($user->id, $room->id));
+        event($roomRepository->addMember($user->id, $room->id));
 
         Event::assertDispatched(MemberAdded::class);
     }

--- a/src/tests/Feature/RoomTest.php
+++ b/src/tests/Feature/RoomTest.php
@@ -586,6 +586,7 @@ class RoomTest extends TestCase
 
         Event::assertDispatched(MemberAdded::class);
     }
+
          /**
      * unameに該当する有効な部屋が存在しない場合は404エラー
      */
@@ -611,7 +612,7 @@ class RoomTest extends TestCase
      * unameに該当する有効な部屋が存在するかつ
      * 入室済の場合は/room/{uname}にリダイレクト
      */
-    public function testEffectRoomFromUnameisMemberRedirectToRoom() 
+    public function testEffectRoomFromUnameisMemberRedirectToRoom()
     {
         $user = factory(User::class)->create();
         $board = $this->createBoard();
@@ -885,3 +886,4 @@ class RoomTest extends TestCase
         $roomId = $repository->getUserJoinActiveRoomId($user->id);
         $this->assertNotNull($roomId);
     }
+}


### PR DESCRIPTION
## 概要
https://github.com/lachelier/sugoroku/issues/58

## 実装内容
MemberAddedクラスにてmember-added-channel-部屋idという形でプライベートチャンネルを作成
addMember()メソッドにて、MemberAddedを発火。送信内容はユーザーidと部屋id