### PR TITLE
#35 ゲームに参加中のユーザは、新しい部屋を作成できないようにする

### DIFF
--- a/src/app/Http/Controllers/RoomController.php
+++ b/src/app/Http/Controllers/RoomController.php
@@ -31,12 +31,12 @@ class RoomController extends Controller
     {
         $repository = new RoomRepository();
 
-        // オープン中の部屋を既に所有していたらエラー
-        $room = $repository->getOwnOpenRoom(Auth::id());
-        if ($room) {
+        // ユーザーが参加中の有効な部屋のIDを返却できたらエラー
+        $activeRoomId = $repository->getUserJoinActiveRoomId(Auth::id());
+        if ($activeRoomId != NULL) {
             return response()->json([
                 'status'    => 'error',
-                'message'   => '既にオープン中の部屋があるようです'
+                'message'   => '既にゲームに参加中の部屋があるようです'
             ]);
         }
 

--- a/src/app/Repositories/RoomRepository.php
+++ b/src/app/Repositories/RoomRepository.php
@@ -195,6 +195,28 @@ class RoomRepository
 
         return $room->spaces;
     }
+
+    /**
+     * ユーザが参加中の有効な部屋のIDを取得
+     */
+    public function getUserJoinActiveRoomId($userId)
+    {
+        $rooms = $this->model::where([
+            'status'        => config('const.room_status_open'),
+            'deleted_at'    => NULL
+        ])->get();
+
+        foreach ($rooms as $room) {
+            $result = Room::find($room->id)->users()->get();
+            foreach ($result as $item) {
+                if ($item->pivot['user_id'] == $userId) {
+                    return $item->pivot['room_id'];
+                }
+            }
+        }
+
+        return NULL;
+    }
 }
 
 

--- a/src/tests/Feature/RoomTest.php
+++ b/src/tests/Feature/RoomTest.php
@@ -84,14 +84,14 @@ class RoomTest extends TestCase
     }
 
     /**
-     * 既にユーザが作ったオープン中の部屋がある場合、新しく部屋を作ることはできない
+     * ゲームに参加中のユーザーは、新しく部屋を作ることはできない
      */
     public function testUserCannotCreateRooms()
     {
         $user = factory(User::class)->create();
         $board = $this->createBoard();
 
-        factory(Room::class)->create([
+        $room = factory(Room::class)->create([
             'uname'     => uniqid(),
             'name'      => 'first room',
             'owner_id'  => $user->id,
@@ -101,13 +101,17 @@ class RoomTest extends TestCase
             'status'    => config('const.room_status_open')
         ]);
 
+        $repository = new RoomRepository();
+        $result = $repository->addMember($user->id, $room->id);
+        $this->assertTrue($result);
+
         $name = 'second room';
         Passport::actingAs($user);
         $response = $this->post('/api/room/create', [
             'name' => $name
         ])->assertJson([
             'status'    => 'error',
-            'message'   => '既にオープン中の部屋があるようです'
+            'message'   => '既にゲームに参加中の部屋があるようです'
         ]);
 
         $this->assertDatabaseMissing('rooms', [
@@ -635,5 +639,31 @@ class RoomTest extends TestCase
             'status'    => 'error',
             'message'   => '入室できませんでした'
         ]);
+    }
+
+    /**
+     * ユーザが参加中の有効な部屋のIDを返す
+     */
+    public function testGetUserJoinActiveRoomId()
+    {
+        $user = factory(User::class)->create();
+        $board = $this->createBoard();
+
+        $room = factory(Room::class)->create([
+            'uname'     => uniqid(),
+            'name'      => 'first room',
+            'owner_id'  => $user->id,
+            'board_id'  => $board->id,
+            'max_member_count'  => 10,
+            'member_count'      => 0,
+            'status'    => config('const.room_status_open'),
+        ]);
+
+        $repository = new RoomRepository();
+        $result = $repository->addMember($user->id, $room->id);
+        $this->assertTrue($result);
+
+        $roomId = $repository->getUserJoinActiveRoomId($user->id);
+        $this->assertNotNull($roomId);
     }
 }


### PR DESCRIPTION
以下Issueの対応になります。
https://github.com/lachelier/sugoroku/issues/35

RoomControllerのstore()のgetOwnOpenRoom()を置き換えたことでテストコード(testUserCannotCreateRooms)も置き換えてます。